### PR TITLE
feat(HU0005): Fixed a focus error using href="/''

### DIFF
--- a/src/app/component/header/header.component.html
+++ b/src/app/component/header/header.component.html
@@ -23,7 +23,7 @@
       <div class="main-header">
         <!-- Logo -->
         <div class="logo">
-          <a href="/">
+          <a (click)="goToHome()">
             <h1>Blanca</h1>
             <h2>y sus <span>rosas</span></h2>
           </a>

--- a/src/app/component/header/header.component.ts
+++ b/src/app/component/header/header.component.ts
@@ -36,4 +36,13 @@ export class HeaderComponent {
       }
     });
   }
+
+  goToHome() {
+    this.router.navigate(['/']).then(() => {
+      const headerSection = document.querySelector('#header');
+      if (headerSection) {
+        headerSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+  }
 }


### PR DESCRIPTION
Fixed a focus error using 'href='/'' to redirect to the… home page, which caused the entire page to be reloaded completely from the server, which breaks the experience of a Single Page Application (SPA), where the purpose is to dynamically load content without reloading the entire page. To fix this, we used routerLink to handle navigation without reloading the page, achieving higher performance by reusing components and resources already loaded.